### PR TITLE
change 'is' to '=='

### DIFF
--- a/slurm-sshare.py
+++ b/slurm-sshare.py
@@ -2,16 +2,13 @@
 
 import sys
 import logging
-import re
 
 # squeue -rh -o '%g %u %P %16b %T %C %D %R'
 assoc_tree_path = []
 
 
 for line in sys.stdin:
- 
-   #logging.info(f"> {line}")
-
+  # logging.info(f"> {line}")
   fields = line.split('|')
 
   if len(fields) == 11:
@@ -36,13 +33,13 @@ for line in sys.stdin:
       assoc_tree_path = assoc_tree_path[:level + 1]
 
     if level_fs:
-      if level_fs is 'inf':
+      if level_fs == 'inf':
         level_fs = sys.maxint
       level_fs = float(level_fs)
       #print( "sshare level_fs=%s share=%f" % ('.'.join(assoc_tree_path), level_fs  ))
   else:
     if level_fs:
-      if level_fs is 'inf':
+      if level_fs == 'inf':
         level_fs = sys.maxint
       level_fs = float(level_fs)
       #print( "sshare level_fs=%s.%s share=%f" % ('.'.join(assoc_tree_path), user, level_fs ) )


### PR DESCRIPTION
Hey folks, thanks for sharing this code! You probably saved me hours of time trying integrate slurm into my influxdb monitoring setup.

Everything basically worked as is on the cluster I maintain. One thing I did see is that python (version 3.8) prints the following warning when running the script.

```
./slurm-sshare.py:39: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if level_fs is 'inf':
./slurm-sshare.py:45: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if level_fs is 'inf':
```

It's not clear to me if telegraf will balk at that output, but I fixed it before adding it to my config to be safe and figured that I would share the changes here.