### PR TITLE
Squeue json

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,3 +9,4 @@ sinfo -h -e -o '%R %m %c %f %G %T %D %C' | python3 ${DIR}/slurm-sinfo.py
 sinfo -Nh -O NodeHost,StateLong,SocketCoreThread,CPUsState,CPUsLoad,Memory,AllocMem,FreeMem,Disk,Weight,Features:100,Gres:100,GresUsed:100,Reason:50 | sort | uniq | python3 ${DIR}/slurm-sinfo-node.py
 sshare -ahlP | python3 ${DIR}/slurm-sshare.py
 python3 ${DIR}/slurm_squeue_json.py -tRunning 1440 -tPending 30
+python3 ${DIR}/slurm_sinfo_json.py

--- a/slurm_sinfo_json.py
+++ b/slurm_sinfo_json.py
@@ -1,0 +1,84 @@
+import subprocess
+import json
+import copy
+import time
+import sys
+import traceback
+import datetime
+
+"""
+    All the parameters from sinfo --json seems to be easy to understand. The
+    parameter weight can be used to diagnose a working node without force
+    that particular node to drain or do a hard reboot. So far weight has the
+    same value for all the working nodes and this paratemer represent a relative
+    value assigned to each node in the cluster that reflects the nodes capacity
+    or performance. Slurm use this information to distribute the jobs across the
+    cluster. with higher-weighted nodes receiving more queue of the total workload
+"""
+
+def influxDBLineProtocol(measurement_name,input_dict):
+    """
+    Function to return the proper format for influxDB line protocol according to:
+    https://docs.influxdata.com/influxdb/v2.7/reference/syntax/line-protocol.
+    Input dict is as follows.
+    {
+        tagvalue1:val1, fieldvalue1:val1, ..., othervalue:valuex ...
+        idb_tags:[tagvalue1, tagvalue2, ...],
+        idb_field:[fieldvalue1, fieldvalue2, ...]
+    }
+    Empty keys values from input dictionary will be treated as None.
+    If the input_dict does not contains pair of keys and values in the list of
+    tags, the tag will have a value of "(null)"
+    If the input_dict does not contains pair of keys and values in the list of
+    fields, the field will have a value of 0
+    """
+
+    input_dict = {key: None if value == '' else value for key, value in input_dict.items()}
+    formatted_tags = [f"{key}={value}" if value is not None else f"{key}=\"\"" for key, value in input_dict.items() if key in input_dict['idb_tags']]
+    formatted_fields = [f"{key}={value}" if value is not None else f"{key}=0" for key, value in input_dict.items() if key in input_dict['idb_fields']]
+
+    formatted_output =','.join([measurement_name] + [','.join(formatted_tags)])
+    formatted_output = formatted_output+' '+','.join(formatted_fields)+' '+str(input_dict['timestamp'])
+
+    return formatted_output
+
+def main():
+    try:
+        timestamp=int(time.time()*1e9)
+        # Execute sinfo
+        sinfo = 'sinfo --json'
+        out_commandline = subprocess.Popen(sinfo, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # Read the standard output and decode it as JSON
+        stdout, stderr = out_commandline.communicate()
+        if stderr:
+            print("Error:", stderr.decode('utf-8'))
+            exit(1)
+        if stdout is None:
+            print("No standard output produced by the subprocess.")
+            exit(1)
+        # Parse the JSON data into a Python dictionary
+        json_sinfo = json.loads(stdout.decode('utf-8'))
+
+
+        attributes2check = ["hostname","state","reason","cpus",
+        "alloc_cpus","idle_cpus","real_memory","alloc_memory","free_memory", "weight",
+        "boot_time", "slurmd_start_time"]
+
+        idb_tags = ["hostname", "state", "weight"]
+        idb_fields = ["alloc_cpus", "idle_cpus", "alloc_memory",
+        "free_memory","boot_time_s","slurmd_start_time_s"]
+
+        for node in json_sinfo['nodes']:
+            sub_dict = {key: node[key] for key in attributes2check if key in node}
+            sub_dict['timestamp'] =  timestamp
+            sub_dict['idb_tags'] = idb_tags
+            sub_dict['idb_fields'] = idb_fields
+            output_formatted=influxDBLineProtocol("sinfo_json",sub_dict)
+            print(output_formatted)
+
+
+    except Exception:
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/slurm_squeue_json.py
+++ b/slurm_squeue_json.py
@@ -78,6 +78,31 @@ def get_working_nodes(string_node):
             nodes.append(f"{prefix}{int(node):03}")
     return nodes
 
+def influxDBLineProtocol(measurement_name,input_dict):
+    """
+    Function to return the proper format for influxDB line protocol according to:
+    https://docs.influxdata.com/influxdb/v2.7/reference/syntax/line-protocol.
+    Input dict is as follows.
+    {
+        tagvalue1:val1, fieldvalue1:val1, ..., othervalue:valuex ...
+        idb_tags:[tagvalue1, tagvalue2, ...],
+        idb_field:[fieldvalue1, fieldvalue2, ...]
+    }
+    Empty keys values from input dictionary will be treated as None.
+    If the input_dict does not contains pair of keys and values in the list of
+    tags, the tag will have a value of "(null)"
+    If the input_dict does not contains pair of keys and values in the list of
+    fields, the field will have a value of 0
+    """
+
+    input_dict = {key: None if value == '' else value for key, value in input_dict.items()}
+    formatted_tags = [f"{key}={value}" if value is not None else f"{key}=\\\"\\\"" for key, value in input_dict.items() if key in input_dict['idb_tags']]
+    formatted_fields = [f"{key}={value}u" if value is not None else f"{key}=0u" for key, value in input_dict.items() if key in input_dict['idb_fields']]
+
+    formatted_output =','.join([measurement_name] + [','.join(formatted_tags)])
+    formatted_output = formatted_output+' '+','.join(formatted_fields)+' '+str(input_dict['timestamp'])
+
+    return formatted_output
 
 def main():
     try:
@@ -85,7 +110,7 @@ def main():
         parser.add_argument("-tRunning", help="Amount of minutes running", type=int, default=1440)
         parser.add_argument("-tPending", help="Amount of minutes pending", type=int, default=30)
         args = parser.parse_args()
-        timestamp=int(time.time())
+        timestamp=int(time.time()*1e9)
 
         # Execute squeue
         squeue = 'squeue --json'
@@ -105,15 +130,14 @@ def main():
                     "job_id", "job_resources", "job_state",
                     "cpus", "node_count", "tasks", "partition", "memory_per_cpu",
                     "priority", "qos", "shared", "start_time", "submit_time",
-                    "user_name"]
+                    "user_name","memory_per_node","state_reason"]
         idb_tags = ["account", "job_state", "partition", "priority", "qos",
                     "user_name","facility","repo","long_pending","long_running",
-                    "multi_partition","multi_host", "node","cpus","memory_per_cpu"]
-        idb_fields = ["job_id","cpus","task","memory","cores"]
+                    "multi_partition","multi_host", "node","state_reason"]
+        idb_fields = ["job_id","cpus","task","memory","cores","memory_per_cpu","memory_per_node"]
 
         for jobs in json_squeue['jobs']:
             sub_dict = {key: jobs[key] for key in attributes2check if key in jobs}
-            sub_dict['job_id'] = str(sub_dict['job_id'])
             sub_dict['timestamp'] =  timestamp
             sub_dict['idb_tags'] = idb_tags
             sub_dict['idb_fields'] = idb_fields
@@ -127,7 +151,7 @@ def main():
             else:
                 sub_dict['facility'] = None
                 sub_dict['repo'] = None
-            if sub_dict['job_state'] == "PENDING" and ((timestamp - sub_dict['submit_time']) > args.tPending*60): #1800 Seconds
+            if sub_dict['job_state'] == "PENDING" and ((timestamp - sub_dict['submit_time']) > args.tPending*60):
                 sub_dict['time_pending'] = timestamp - sub_dict['submit_time']
                 sub_dict['long_pending'] = True
             else:
@@ -158,14 +182,14 @@ def main():
                             sub_dict['cores']=sub_dict['job_resources']['allocated_nodes'][nodenumber]['cpus']
                             dict_influxdb=copy.deepcopy(sub_dict)
                             del dict_influxdb['job_resources']
-                            formatted_dict = ', '.join(f"'{key}'={value}" for key, value in dict_influxdb.items())
-                            print("squeue_json,",formatted_dict)
+                            output_formatted=influxDBLineProtocol("squeue_json",dict_influxdb)
+                            print(output_formatted)
                     else:
                         dict_influxdb=copy.deepcopy(sub_dict)
                         del dict_influxdb['job_resources']
-                        formatted_dict = ', '.join(f"'{key}'={value}" for key, value in dict_influxdb.items())
-                        print("squeue_json,",formatted_dict)
-                        #continue
+                        output_formatted=influxDBLineProtocol("squeue_json",dict_influxdb)
+                        print(output_formatted)
+
             else:
                 sub_dict['multi_partition'] = False
                 if len(sub_dict['job_resources'])!=0:
@@ -181,8 +205,8 @@ def main():
                             sub_dict['cores']=sub_dict['job_resources']['allocated_nodes'][nodenumber]['cpus']
                             dict_influxdb=copy.deepcopy(sub_dict)
                             del dict_influxdb['job_resources']
-                            formatted_dict = ', '.join(f"'{key}'={value}" for key, value in dict_influxdb.items())
-                            print("squeue_json,",formatted_dict)
+                            output_formatted=influxDBLineProtocol("squeue_json",dict_influxdb)
+                            print(output_formatted)
     except Exception:
         traceback.print_exc()
 


### PR DESCRIPTION
After local testing, the output 
```
squeue_json,account=\"\",job_state=RUNNING,partition=milano,priority=24,qos=normal,user_name=mdimauro,facility=\"\",repo=\"\",long_pending=False,long_running=True,multi_partition=False,multi_host=True,node=sdfmilan016 job_id=18370826u,cpus=512u,memory_per_cpu=4096u,memory=65536u,cores=16u 1688144391669275904
```
can be tested using `telegraf --config telegraf.conf --test` showing the following output:
```
telegraf --config telegraf.conf --test
2023-06-30T17:09:45Z I! Loading config: telegraf.conf
2023-06-30T17:09:45Z I! Starting Telegraf 1.27.1
2023-06-30T17:09:45Z I! Available plugins: 237 inputs, 9 aggregators, 28 processors, 23 parsers, 59 outputs, 4 secret-stores
2023-06-30T17:09:45Z I! Loaded inputs: exec
2023-06-30T17:09:45Z I! Loaded aggregators: 
2023-06-30T17:09:45Z I! Loaded processors: 
2023-06-30T17:09:45Z I! Loaded secretstores: 
2023-06-30T17:09:45Z W! Outputs are not used in testing mode!
2023-06-30T17:09:45Z I! Tags enabled: host=MAC-142381
> squeue_json,account="",facility="",host=MAC-142381,job_state=RUNNING,long_pending=False,long_running=True,multi_host=True,multi_partition=False,node=sdfmilan016,partition=milano,priority=24,qos=normal,repo="",user_name=mdimauro cores=16i,cpus=512i,job_id=18370826i,memory=65536i,memory_per_cpu=4096i 1688144392000000000
```

