### PR TITLE
Map Rubin queue to Slurm jobs

### DIFF
--- a/slurm_squeue_json.py
+++ b/slurm_squeue_json.py
@@ -95,7 +95,7 @@ def influxDBLineProtocol(measurement_name,input_dict):
     fields, the field will have a value of 0
     """
 
-    input_dict = {key: '_' if '.' in value else (None if value == '' else value) for key, value in input_dict.items()}
+    input_dict = {key: value.replace('.', '_') if isinstance(value, str) and '.' in value else (None if value == '' else value) for key, value in input_dict.items()}
     formatted_tags = [f"{key}={value}" if value is not None else f"{key}=\\\"\\\"" for key, value in input_dict.items() if key in input_dict['idb_tags']]
     formatted_fields = [f"{key}={value}u" if value is not None else f"{key}=0u" for key, value in input_dict.items() if key in input_dict['idb_fields']]
 

--- a/slurm_squeue_json.py
+++ b/slurm_squeue_json.py
@@ -95,7 +95,7 @@ def influxDBLineProtocol(measurement_name,input_dict):
     fields, the field will have a value of 0
     """
 
-    input_dict = {key: None if value == '' else value for key, value in input_dict.items()}
+    input_dict = {key: '_' if '.' in value else (None if value == '' else value) for key, value in input_dict.items()}
     formatted_tags = [f"{key}={value}" if value is not None else f"{key}=\\\"\\\"" for key, value in input_dict.items() if key in input_dict['idb_tags']]
     formatted_fields = [f"{key}={value}u" if value is not None else f"{key}=0u" for key, value in input_dict.items() if key in input_dict['idb_fields']]
 

--- a/slurm_squeue_json.py
+++ b/slurm_squeue_json.py
@@ -141,6 +141,9 @@ def main():
             sub_dict['timestamp'] =  timestamp
             sub_dict['idb_tags'] = idb_tags
             sub_dict['idb_fields'] = idb_fields
+            # lsstsvc1 is the only user interested in mapping name for slurm jobs
+            if sub_dict.get('user_name') != 'lsstsvc1':
+                del sub_dict['name']
             #Add new concept to monitor resources by experiment and by sesion.
             if ":" in sub_dict['account']:
                 facility_repo=sub_dict['account'].split(":")

--- a/slurm_squeue_json.py
+++ b/slurm_squeue_json.py
@@ -130,10 +130,10 @@ def main():
                     "job_id", "job_resources", "job_state",
                     "cpus", "node_count", "tasks", "partition", "memory_per_cpu",
                     "priority", "qos", "shared", "start_time", "submit_time",
-                    "user_name","memory_per_node","state_reason"]
+                    "user_name","memory_per_node","state_reason","name"]
         idb_tags = ["account", "job_state", "partition", "priority", "qos",
                     "user_name","facility","repo","long_pending","long_running",
-                    "multi_partition","multi_host", "node","state_reason"]
+                    "multi_partition","multi_host", "node","state_reason","name"]
         idb_fields = ["job_id","cpus","task","memory","cores","memory_per_cpu","memory_per_node"]
 
         for jobs in json_squeue['jobs']:


### PR DESCRIPTION
**squash needed**
lsstvc1 wants to map the PanDA queue to the slurm jobs (since slurm doesn't know the concept of queue). With these changes `lsstsvc1` will be able to check from which queue the jobs are running/pending. The mapping is the following:

```
	  "localQueueName": "test",  {"SLAC_TEST"}
	  "localQueueName": "rubin", { "SLAC_Rubin"}
	  "localQueueName": "medium", {"SLAC_Rubin_Medium"}
	  "localQueueName": "himem", {"SLAC_Rubin_Himem"}
	  "localQueueName": "extra_himem", {"SLAC_Rubin_Extra_Himem"} 
	  "localQueueName": "ehimem_32", {SLAC_Rubin_Extra_Himem_32Cores"}
	  "localQueueName": "merge", {"SLAC_Rubin_Merge"}
```

The output with this changes are the following.
```
...
squeue_json,account=rubin,job_state=RUNNING,partition=roma,priority=1,qos=normal,user_name=lsstsvc1,state_reason=None,name=rubin_grid,facility=\"\",repo=\"\",long_pending=False,long_running=True,multi_partition=False,multi_host=False,node=sdfrome036 job_id=25317012u,cpus=1u,memory_per_cpu=8193u,memory_per_node=0u,memory=8193u,cores=1u 1692894861392495104
squeue_json,account=rubin,job_state=RUNNING,partition=roma,priority=1,qos=normal,user_name=lsstsvc1,state_reason=None,name=rubin_himem,facility=\"\",repo=\"\",long_pending=False,long_running=True,multi_partition=False,multi_host=False,node=sdfrome022 job_id=25316998u,cpus=1u,memory_per_cpu=18001u,memory_per_node=0u,memory=18001u,cores=1u 1692894861392495104
...
```
@yee379 Do you think other users using the facility will profit of this changes? 