### PR TITLE
support ^ info for accounts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,10 +3,9 @@
 export PATH=$PATH:/opt/slurm/bin
 
 DIR=$( dirname "${BASH_SOURCE[0]}" )
-squeue -rh -O jobid,state,username,Partition,Account,Qos,NumTasks,tres-alloc:100,Reason:70 | python3 ${DIR}/slurm-squeue.py
+squeue -rh -O "jobid:|,state:|,username:|,Partition:|,Account:|,Qos:|,NumTasks:|,tres-alloc:|,Reason:70" | python3 ${DIR}/slurm-squeue.py
 sdiag | python3 ${DIR}/slurm-sdiag.py
 sinfo -h -e -o '%R %m %c %f %G %T %D %C' | python3 ${DIR}/slurm-sinfo.py
 sinfo -Nh -O NodeHost,StateLong,SocketCoreThread,CPUsState,CPUsLoad,Memory,AllocMem,FreeMem,Disk,Weight,Features:100,Gres:100,GresUsed:100,Reason:50 | sort | uniq | python3 ${DIR}/slurm-sinfo-node.py
-sshare -ahlP | python3 ${DIR}/slurm-sshare.py
 python3 ${DIR}/slurm_squeue_json.py -tRunning 1440 -tPending 30
 python3 ${DIR}/slurm_sinfo_json.py

--- a/slurm-squeue.py
+++ b/slurm-squeue.py
@@ -8,22 +8,22 @@ running = {}
 other = {}
 
 for line in sys.stdin:
- 
   #logging.error(f"\n> {line}")
   this = {}
 
   try:
-    out = line.strip().split()
+    out = line.strip().split('|')
 
     this['jobid'] = out.pop(0)
     this['state'] = out.pop(0)
     this['user'] = out.pop(0)
     this['partition'] = out.pop(0).replace(',', '_').replace('\ ', '')
     this['account'] = out.pop(0)
+    if '^' in this['account']:
+        this['account'] = this['account'].split('^')[0]
     this['qos'] = out.pop(0)
 
     this['tasks'] = out.pop(0)
- 
     tres = out.pop(0)
 
     this['reason'] = str(' '.join(out)).replace(' ','\ ')
@@ -94,4 +94,3 @@ for (state, reason, user, partition, account, qos), data in other.items():
     values = [ f"{k}={data[k]}i" for k in data.keys() ]
     this_reason = reason.replace('\ ', '')
     print( f"squeue,user={user},partition={partition},account={account},qos={qos},state={state},reason={this_reason} {','.join(values)}" )
-

--- a/slurm_squeue_json.py
+++ b/slurm_squeue_json.py
@@ -147,6 +147,8 @@ def main():
 
         for jobs in json_squeue['jobs']:
             sub_dict = {key: jobs[key] for key in attributes2check if key in jobs}
+            if '^' in sub_dict['account']:
+                sub_dict['account'] = sub_dict['account'].split('^')[0]
             sub_dict['timestamp'] =  timestamp
             sub_dict['idb_tags'] = idb_tags
             sub_dict['idb_fields'] = idb_fields


### PR DESCRIPTION
Add `|` to separate fields. This is to avoid the error below when the string from account get mixed with qos.
```
WARNING:root: Could not parse not enough values to unpack (expected 2, got 1): 33398247            RUNNING             kocevski            milano              fermi:other-pipelinenormal              1                   cpu=1,mem=8000M,node=1,billing=1                                                                    None 
```  
split by | and modify info from account
modify info for account
delete sshare info

This is to support information of the account with `^` like `lcls:xcsl1004621^normal`